### PR TITLE
AN-2944/op-price-pivot

### DIFF
--- a/models/gold/core__ez_eth_transfers.sql
+++ b/models/gold/core__ez_eth_transfers.sql
@@ -25,17 +25,11 @@ WITH eth_base AS (
 eth_price AS (
     SELECT
         HOUR,
-        AVG(price) AS eth_price
+        price AS eth_price
     FROM
-        {{ source(
-            'ethereum',
-            'fact_hourly_token_prices'
-        ) }}
+        {{ ref('core__fact_hourly_token_prices') }}
     WHERE
-        token_address IS NULL
-        AND symbol IS NULL
-    GROUP BY
-        HOUR
+        token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 )
 SELECT
     A.tx_hash AS tx_hash,

--- a/models/gold/core__ez_eth_transfers.sql
+++ b/models/gold/core__ez_eth_transfers.sql
@@ -20,16 +20,25 @@ WITH eth_base AS (
     WHERE
         eth_value > 0
         AND tx_status = 'SUCCESS'
-        and gas_used is not null
+        AND gas_used IS NOT NULL
 ),
 eth_price AS (
     SELECT
         HOUR,
         price AS eth_price
     FROM
-        {{ ref('core__fact_hourly_token_prices') }}
+        {{ source(
+            'ethereum',
+            'fact_hourly_token_prices'
+        ) }}
     WHERE
-        token_address = '0x4200000000000000000000000000000000000006'
+        token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        AND HOUR :: DATE IN (
+            SELECT
+                DISTINCT block_timestamp :: DATE
+            FROM
+                eth_base
+        )
 )
 SELECT
     A.tx_hash AS tx_hash,

--- a/models/gold/core__ez_eth_transfers.sql
+++ b/models/gold/core__ez_eth_transfers.sql
@@ -29,7 +29,7 @@ eth_price AS (
     FROM
         {{ ref('core__fact_hourly_token_prices') }}
     WHERE
-        token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        token_address = '0x4200000000000000000000000000000000000006'
 )
 SELECT
     A.tx_hash AS tx_hash,

--- a/models/gold/core__ez_eth_transfers.sql
+++ b/models/gold/core__ez_eth_transfers.sql
@@ -33,12 +33,6 @@ eth_price AS (
         ) }}
     WHERE
         token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
-        AND HOUR :: DATE IN (
-            SELECT
-                DISTINCT block_timestamp :: DATE
-            FROM
-                eth_base
-        )
 )
 SELECT
     A.tx_hash AS tx_hash,

--- a/models/gold/core__ez_token_transfers.sql
+++ b/models/gold/core__ez_token_transfers.sql
@@ -1,0 +1,45 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true }
+) }}
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    from_address,
+    to_address,
+    raw_amount,
+    decimals,
+    symbol,
+    price AS token_price,
+    CASE
+        WHEN decimals IS NOT NULL THEN raw_amount / pow(
+            10,
+            decimals
+        )
+        ELSE NULL
+    END AS amount,
+    CASE
+        WHEN decimals IS NOT NULL AND price IS NOT NULL THEN amount * price
+        ELSE NULL
+    END AS amount_usd,
+    CASE
+        WHEN decimals IS NULL THEN 'false'
+        ELSE 'true'
+    END AS has_decimal,
+    CASE
+        WHEN price IS NULL THEN 'false'
+        ELSE 'true'
+    END AS has_price,
+    _log_id
+FROM
+    {{ ref('core__fact_token_transfers') }} t
+LEFT JOIN {{ ref('core__fact_hourly_token_prices') }} p 
+    ON t.contract_address = p.token_address 
+        AND DATE_TRUNC('hour', t.block_timestamp) = HOUR

--- a/models/gold/core__ez_token_transfers.yml
+++ b/models/gold/core__ez_token_transfers.yml
@@ -1,0 +1,42 @@
+version: 2
+models:
+  - name: core__ez_token_transfers
+    description: '{{ doc("opt_transfer_table_doc") }}'
+      
+    columns:
+      - name: BLOCK_NUMBER
+        description: '{{ doc("opt_block_number") }}'   
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("opt_block_timestamp") }}'
+      - name: TX_HASH
+        description: '{{ doc("opt_transfer_tx_hash") }}'
+      - name: CONTRACT_ADDRESS
+        description: '{{ doc("opt_transfer_contract_address") }}'
+      - name: FROM_ADDRESS
+        description: '{{ doc("opt_transfer_from_address") }}'
+      - name: TO_ADDRESS
+        description: '{{ doc("opt_transfer_to_address") }}'
+      - name: RAW_AMOUNT
+        description: '{{ doc("opt_transfer_raw_amount") }}'
+      - name: DECIMALS
+        description: 'The number of decimal places this contract needs adjusted where token values exist.'
+      - name: SYMBOL
+        description: 'The symbol belonging to the address of the token.'
+      - name: TOKEN_PRICE
+        description: '{{ doc("opt_transfer_token_price") }}'
+      - name: AMOUNT
+        description: '{{ doc("opt_transfer_amount") }}'
+      - name: AMOUNT_USD
+        description: '{{ doc("opt_transfer_amount_usd") }}'
+      - name: HAS_DECIMAL
+        description: '{{ doc("opt_transfer_has_decimal") }}'
+      - name: HAS_PRICE
+        description: '{{ doc("opt_transfer_has_price") }}'
+      - name: _LOG_ID
+        description: '{{ doc("opt_log_id_transfers") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("opt_origin_sig") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("opt_eth_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("opt_eth_origin_to") }}'

--- a/models/gold/core__fact_hourly_token_prices.sql
+++ b/models/gold/core__fact_hourly_token_prices.sql
@@ -12,4 +12,8 @@ SELECT
     price,
     is_imputed
 FROM
-    {{ ref('silver__prices') }}
+    {{ source(
+        'crosschain',
+        'ez_hourly_prices'
+    ) }}
+WHERE blockchain = 'optimism'

--- a/models/gold/core__fact_hourly_token_prices.yml
+++ b/models/gold/core__fact_hourly_token_prices.yml
@@ -18,6 +18,6 @@ models:
       - name: DECIMALS
         description: 'The decimals for this token.'
       - name: PRICE
-        description: 'The average hourly price for this token.'
+        description: 'The closing hourly price for this token.'
       - name: IS_IMPUTED
         description: 'This column denotes if we carried forward the last recorded price in order to fill hourly gaps from the source. Either true or false.'

--- a/models/gold/core__fact_hourly_token_prices.yml
+++ b/models/gold/core__fact_hourly_token_prices.yml
@@ -7,8 +7,12 @@ models:
     columns:
       - name: HOUR
         description: 'The hour the token price was recorded.'
+        tests:
+          - not_null
       - name: TOKEN_ADDRESS
         description: 'The Optimism contract address for this token. This is the column used to join to token contract addresses in the other event tables.'
+        tests:
+          - not_null
       - name: SYMBOL
         description: 'The symbol for this token.'
       - name: DECIMALS

--- a/models/quixotic/silver__opensea_seaport.sql
+++ b/models/quixotic/silver__opensea_seaport.sql
@@ -340,14 +340,10 @@ all_prices AS (
         HOUR,
         decimals,
         symbol,
-        CASE
-            WHEN LOWER(token_address) IS NULL
-            AND symbol = 'ETH' THEN 'ETH'
-            ELSE LOWER(token_address)
-        END AS currency_address,
+        token_address AS currency_address,
         price
     FROM
-        {{ ref('silver__prices') }}
+        {{ ref('core__fact_hourly_token_prices') }}
     WHERE
         (
             currency_address IN (

--- a/models/quixotic/silver__quixotic_revamped_sales.sql
+++ b/models/quixotic/silver__quixotic_revamped_sales.sql
@@ -529,14 +529,10 @@ hourly_prices AS (
     SELECT
         HOUR,
         symbol,
-        CASE
-            WHEN token_address IS NULL
-            AND symbol = 'ETH' THEN 'ETH'
-            ELSE token_address
-        END AS currency_address,
+        token_address AS currency_address,
         price AS token_price
     FROM
-        {{ ref('silver__prices') }}
+        {{ ref('core__fact_hourly_token_prices') }}
     WHERE
         HOUR :: DATE IN (
             SELECT

--- a/models/silver/silver__prices.sql
+++ b/models/silver/silver__prices.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     unique_key = 'price_id',
+    enabled = false,
     cluster_by = ['hour::DATE', 'token_address']
 ) }}
 

--- a/models/silver/silver__prices.yml
+++ b/models/silver/silver__prices.yml
@@ -1,25 +1,25 @@
 version: 2
 models:
   - name: silver__prices
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - HOUR
-            - TOKEN_ADDRESS
-    columns:
-      - name: HOUR
-        tests:
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
-      - name: PRICE
-        tests:
-          - not_null
-      - name: TOKEN_ADDRESS
-        tests:
-          - not_null:
-              where: SYMBOL <> 'ETH'
-      - name: SYMBOL
-        tests:
-          - not_null:
-              where: TOKEN_ADDRESS <> '0x1e3c6c53f9f60bf8aae0d7774c21fa6b1afddc57'
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - HOUR
+    #         - TOKEN_ADDRESS
+    # columns:
+    #   - name: HOUR
+    #     tests:
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 1
+    #   - name: PRICE
+    #     tests:
+    #       - not_null
+    #   - name: TOKEN_ADDRESS
+    #     tests:
+    #       - not_null:
+    #           where: SYMBOL <> 'ETH'
+    #   - name: SYMBOL
+    #     tests:
+    #       - not_null:
+    #           where: TOKEN_ADDRESS <> '0x1e3c6c53f9f60bf8aae0d7774c21fa6b1afddc57'

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -12,6 +12,7 @@ sources:
     schema: core
     tables:
       - name: address_labels
+      - name: ez_hourly_prices
   - name: ethereum
     database: ethereum
     schema: core

--- a/models/sushi/sushi__dim_dex_pools.sql
+++ b/models/sushi/sushi__dim_dex_pools.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'table',
+    enabled = false,
     meta={
         'database_tags':{
             'table': {

--- a/models/sushi/sushi__ez_swaps.sql
+++ b/models/sushi/sushi__ez_swaps.sql
@@ -4,6 +4,7 @@
     "columns": true },
     unique_key = '_log_id',
     cluster_by = ['block_timestamp::DATE'],
+    enabled = false,
     meta={
         'database_tags':{
             'table': {

--- a/models/sushi/sushi__ez_swaps.yml
+++ b/models/sushi/sushi__ez_swaps.yml
@@ -1,135 +1,135 @@
 version: 2
 models:
   - name: sushi__ez_swaps
-    description: Deprecating soon
+    # description: Deprecating soon
 
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - _LOG_ID
-    columns:
-      - name: BLOCK_NUMBER
-        description: '{{ doc("opt_block_number") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: BLOCK_TIMESTAMP
-        description: '{{ doc("opt_block_timestamp") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 2 #might be normal for swaps not to happen on a day
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - TIMESTAMP_NTZ
-      - name: TX_HASH
-        description: '{{ doc("opt_logs_tx_hash") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: CONTRACT_ADDRESS
-        description: '{{ doc("opt_logs_contract_address") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: AMOUNT_IN
-        description: '{{ doc("eth_dex_swaps_amount_in") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_OUT
-        description: '{{ doc("eth_dex_swaps_amount_out") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_IN_USD
-        description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: AMOUNT_OUT_USD
-        description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: TOKEN_IN
-        description: '{{ doc("eth_dex_swaps_token_in") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
+    # tests:
+    #   - dbt_utils.unique_combination_of_columns:
+    #       combination_of_columns:
+    #         - _LOG_ID
+    # columns:
+    #   - name: BLOCK_NUMBER
+    #     description: '{{ doc("opt_block_number") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: BLOCK_TIMESTAMP
+    #     description: '{{ doc("opt_block_timestamp") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_row_values_to_have_recent_data:
+    #           datepart: day
+    #           interval: 2 #might be normal for swaps not to happen on a day
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - TIMESTAMP_NTZ
+    #   - name: TX_HASH
+    #     description: '{{ doc("opt_logs_tx_hash") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: CONTRACT_ADDRESS
+    #     description: '{{ doc("opt_logs_contract_address") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: AMOUNT_IN
+    #     description: '{{ doc("eth_dex_swaps_amount_in") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_OUT
+    #     description: '{{ doc("eth_dex_swaps_amount_out") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_IN_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: AMOUNT_OUT_USD
+    #     description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: TOKEN_IN
+    #     description: '{{ doc("eth_dex_swaps_token_in") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
 
-      - name: TOKEN_OUT
-        description: '{{ doc("eth_dex_swaps_token_out") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: SYMBOL_IN
-        description: '{{ doc("eth_dex_swaps_symbol_in") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: SYMBOL_OUT
-        description: '{{ doc("eth_dex_swaps_symbol_out") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: TX_TO
-        description: '{{ doc("eth_dex_swaps_tx_to") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: PLATFORM
-        description: '{{ doc("eth_dex_platform") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - STRING
-                - VARCHAR
-      - name: EVENT_INDEX
-        description: '{{ doc("opt_event_index") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list:
-                - NUMBER
-                - FLOAT
-      - name: _LOG_ID
-        description: '{{ doc("opt_log_id_events") }}'
-        tests:
-          - not_null
-      - name: ORIGIN_FUNCTION_SIGNATURE
-        description: '{{ doc("opt_tx_origin_sig") }}'
-        tests:
-          - not_null
-      - name: ORIGIN_FROM_ADDRESS
-        description: '{{ doc("opt_origin_from") }}'
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
-      - name: ORIGIN_TO_ADDRESS
-        description: '{{ doc("opt_origin_to") }}'
-        tests:
-          - dbt_expectations.expect_column_values_to_match_regex:
-              regex: 0[xX][0-9a-fA-F]+
+    #   - name: TOKEN_OUT
+    #     description: '{{ doc("eth_dex_swaps_token_out") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: SYMBOL_IN
+    #     description: '{{ doc("eth_dex_swaps_symbol_in") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: SYMBOL_OUT
+    #     description: '{{ doc("eth_dex_swaps_symbol_out") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: TX_TO
+    #     description: '{{ doc("eth_dex_swaps_tx_to") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: PLATFORM
+    #     description: '{{ doc("eth_dex_platform") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - STRING
+    #             - VARCHAR
+    #   - name: EVENT_INDEX
+    #     description: '{{ doc("opt_event_index") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_be_in_type_list:
+    #           column_type_list:
+    #             - NUMBER
+    #             - FLOAT
+    #   - name: _LOG_ID
+    #     description: '{{ doc("opt_log_id_events") }}'
+    #     tests:
+    #       - not_null
+    #   - name: ORIGIN_FUNCTION_SIGNATURE
+    #     description: '{{ doc("opt_tx_origin_sig") }}'
+    #     tests:
+    #       - not_null
+    #   - name: ORIGIN_FROM_ADDRESS
+    #     description: '{{ doc("opt_origin_from") }}'
+    #     tests:
+    #       - not_null
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
+    #   - name: ORIGIN_TO_ADDRESS
+    #     description: '{{ doc("opt_origin_to") }}'
+    #     tests:
+    #       - dbt_expectations.expect_column_values_to_match_regex:
+    #           regex: 0[xX][0-9a-fA-F]+
 


### PR DESCRIPTION
1. Changed source for `core.fact_hourly_token_prices` to `crosschain.ez_hourly_prices`
2. Replaced any references to `silver` prices with the `core` view and disabled it
3. Disabled sushi models as part of deprecation process