### PR TITLE
AN-3306/swap-public-to-utils

### DIFF
--- a/models/silver/dex/beethovenx/silver_dex__beethovenx_pools.sql
+++ b/models/silver/dex/beethovenx/silver_dex__beethovenx_pools.sql
@@ -153,7 +153,7 @@ SELECT
     MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_name,
     MIN(CASE 
             WHEN read_result::STRING = '0x' THEN NULL
-            ELSE ethereum.public.udf_hex_to_int(read_result::STRING)
+            ELSE utils.udf_hex_to_int(read_result::STRING)
         END)::INTEGER  AS pool_decimals,
     MAX(_inserted_timestamp) AS _inserted_timestamp
 FROM pool_details

--- a/models/silver/dex/beethovenx/silver_dex__beethovenx_swaps.sql
+++ b/models/silver/dex/beethovenx/silver_dex__beethovenx_swaps.sql
@@ -27,13 +27,13 @@ swaps_base AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         (CASE 
             WHEN segmented_data [0] = '0x' THEN NULL 
-            ELSE ethereum.public.udf_hex_to_int(
+            ELSE utils.udf_hex_to_int(
             segmented_data [0] :: STRING
                 )
             END) :: INTEGER AS amount_in_unadj,
         (CASE 
             WHEN segmented_data [1] = '0x' THEN NULL 
-            ELSE ethereum.public.udf_hex_to_int(
+            ELSE utils.udf_hex_to_int(
             segmented_data [1] :: STRING
                 ) 
             END) :: INTEGER AS amount_out_unadj,

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -284,7 +284,7 @@ SELECT
         TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
     MIN(CASE 
             WHEN p.read_result::STRING = '0x' THEN NULL
-            ELSE ethereum.public.udf_hex_to_int(LEFT(p.read_result::STRING,66))
+            ELSE utils.udf_hex_to_int(LEFT(p.read_result::STRING,66))
         END)::INTEGER  AS pool_decimals,
     CONCAT(
         t.contract_address,

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -55,16 +55,16 @@ curve_base AS (
         pool_name,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         )) AS sold_id,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         )) AS tokens_sold,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         )) AS bought_id,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         )) AS tokens_bought,
         _log_id,
@@ -109,7 +109,7 @@ token_transfers AS (
         tx_hash,
         contract_address AS token_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 DATA :: STRING
             )
         ) AS amount,

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -46,12 +46,12 @@ swaps_base AS (
             )
         ) AS toToken,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS fromAmount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS toAmount,

--- a/models/silver/dex/frax/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/frax/silver_dex__fraxswap_pools.sql
@@ -15,7 +15,7 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INT AS pool_id,
         _log_id,

--- a/models/silver/dex/frax/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/frax/silver_dex__fraxswap_swaps.sql
@@ -27,22 +27,22 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS amount1Out,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -16,17 +16,17 @@ WITH pool_creation AS (
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
         CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS ampBps,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         ) AS feeUnits,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             )
         ) AS totalPool,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -27,27 +27,27 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS amount0In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS amount1In,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS amount0Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS amount1Out,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [4] :: STRING
             )
         ) AS feeInPrecision,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -14,9 +14,9 @@ WITH pool_creation AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
-        TRY_TO_NUMBER(ethereum.public.udf_hex_to_int(topics [3] :: STRING)) AS swapFeeUnits,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(topics [3] :: STRING)) AS swapFeeUnits,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             )
         ) AS tickDistance,

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -27,29 +27,29 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS reipient_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [0] :: STRING
             )
         ) AS deltaQty0,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [1] :: STRING
             )
         ) AS deltaQty1,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS sqrtP,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [3] :: STRING
             )
         ) AS liquidity,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 's2c',
                 l_segmented_data [4] :: STRING
             )

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -25,12 +25,12 @@ swaps_base AS (
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             )
         ) AS amountOut,

--- a/models/silver/dex/synthetix/silver_dex__synthetix_swaps.sql
+++ b/models/silver/dex/synthetix/silver_dex__synthetix_swaps.sql
@@ -17,10 +17,10 @@ WITH swaps_base AS (
         'Swap' AS event_name,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INTEGER AS amount_in_unadj,
-        PUBLIC.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS amount_out_unadj,
         REGEXP_REPLACE(HEX_DECODE_STRING(

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -13,11 +13,11 @@ WITH created_pools AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         LOWER(CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40))) AS token0_address,
         LOWER(CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))) AS token1_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             topics [3] :: STRING
         ) :: INTEGER AS fee,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [0] :: STRING
         ) :: INTEGER AS tick_spacing,
@@ -44,8 +44,8 @@ initial_info AS (
     SELECT
         contract_address,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        ethereum.public.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [0] :: STRING)) :: FLOAT AS init_sqrtPriceX96,
-        ethereum.public.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [1] :: STRING)) :: FLOAT AS init_tick,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [0] :: STRING)) :: FLOAT AS init_sqrtPriceX96,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [1] :: STRING)) :: FLOAT AS init_tick,
         pow(
             1.0001,
             init_tick

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -11,23 +11,23 @@ WITH base_swaps AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS recipient,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [0] :: STRING
         ) :: FLOAT AS amount0_unadj,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [1] :: STRING
         ) :: FLOAT AS amount1_unadj,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [2] :: STRING
         ) :: FLOAT AS sqrtPriceX96,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [3] :: STRING
         ) :: FLOAT AS liquidity,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             's2c',
             segmented_data [4] :: STRING
         ) :: FLOAT AS tick

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -20,17 +20,17 @@ WITH router_swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_token,
         CONCAT('0x', SUBSTR(l.topics [3] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS swapType,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS fromAmount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [2] :: STRING
             )
         ) AS toAmount,
@@ -85,12 +85,12 @@ swaps_base AS (
         CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_token,
         CONCAT('0x', SUBSTR(l.topics [3] :: STRING, 27, 40)) AS to_address,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [0] :: STRING
             )
         ) AS fromAmount,
         TRY_TO_NUMBER(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 l_segmented_data [1] :: STRING
             )
         ) AS toAmount,

--- a/models/silver/silver__blocks.sql
+++ b/models/silver/silver__blocks.sql
@@ -39,24 +39,24 @@ all_records AS (
         network :: STRING AS network,
         chain_id :: STRING AS blockchain,
         tx_count :: INTEGER AS tx_count,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             header :difficulty :: STRING
         ) :: INTEGER AS difficulty,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             header :totalDifficulty :: STRING
         ) :: INTEGER AS total_difficulty,
         header: extraData :: STRING AS extra_data,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             header :gasLimit :: STRING
         ) :: INTEGER AS gas_limit,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             header :gasUsed :: STRING
         ) :: INTEGER AS gas_used,
         header: "hash" :: STRING AS HASH,
         header: parentHash :: STRING AS parent_hash,
         header: receiptsRoot :: STRING AS receipts_root,
         header: sha3Uncles :: STRING AS sha3_uncles,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             header: "size" :: STRING
         ) :: INTEGER AS SIZE,
         CASE

--- a/models/silver/silver__contracts.sql
+++ b/models/silver/silver__contracts.sql
@@ -35,7 +35,7 @@ token_names AS (
         function_signature,
         read_output,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [1] :: STRING
         ) AS sub_len,
         TRY_HEX_DECODE_STRING(
@@ -69,7 +69,7 @@ token_symbols AS (
         function_signature,
         read_output,
         regexp_substr_all(SUBSTR(read_output, 3, len(read_output)), '.{64}') AS segmented_output,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_output [1] :: STRING
         ) AS sub_len,
         TRY_HEX_DECODE_STRING(
@@ -99,7 +99,7 @@ token_symbols AS (
 token_decimals AS (
     SELECT
         contract_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             read_output :: STRING
         ) AS token_decimals,
         LENGTH(token_decimals) AS dec_length

--- a/models/silver/silver__logs.sql
+++ b/models/silver/silver__logs.sql
@@ -67,7 +67,7 @@ logs AS (
         tx_status,
         ingested_at,
         _inserted_timestamp,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             VALUE :logIndex :: STRING
         ) :: INTEGER AS event_index,
         VALUE :address :: STRING AS contract_address,

--- a/models/silver/silver__traces.sql
+++ b/models/silver/silver__traces.sql
@@ -96,10 +96,10 @@ base_table AS (
 flattened_traces AS (
     SELECT
         DATA :from :: STRING AS from_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :gas :: STRING
         ) AS gas,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             DATA :gasUsed :: STRING
         ) AS gas_used,
         DATA :input :: STRING AS input,
@@ -108,7 +108,7 @@ flattened_traces AS (
         DATA :to :: STRING AS to_address,
         DATA :type :: STRING AS TYPE,
         CASE
-            WHEN DATA :type :: STRING = 'CALL' THEN ethereum.public.udf_hex_to_int(
+            WHEN DATA :type :: STRING = 'CALL' THEN utils.udf_hex_to_int(
                 DATA :value :: STRING
             ) / pow(
                 10,

--- a/models/silver/silver__transactions.sql
+++ b/models/silver/silver__transactions.sql
@@ -10,14 +10,14 @@ WITH base_table AS (
         block_timestamp,
         block_id :: INTEGER AS block_number,
         tx_id :: STRING AS tx_hash,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             tx :nonce :: STRING
         ) :: INTEGER AS nonce,
         tx_block_index :: INTEGER AS POSITION,
         tx :from :: STRING AS from_address,
         tx :to :: STRING AS to_address,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 tx :value :: STRING
             ) / pow(
                 10,
@@ -26,11 +26,11 @@ WITH base_table AS (
         ) :: FLOAT AS eth_value,
         tx :blockHash :: STRING AS block_hash,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 tx :gasPrice :: STRING
             )
         ) :: FLOAT AS gas_price,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             tx :gas :: STRING
         ) :: INTEGER AS gas_limit,
         tx :input :: STRING AS DATA,
@@ -38,13 +38,13 @@ WITH base_table AS (
             WHEN tx :receipt :status :: STRING = '0x1' THEN 'SUCCESS'
             ELSE 'FAIL'
         END AS status,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             tx :receipt :gasUsed :: STRING
         ) :: INTEGER AS gas_used,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             tx :receipt :cumulativeGasUsed :: STRING
         ) :: INTEGER AS cumulative_Gas_Used,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             tx :receipt :effectiveGasPrice :: STRING
         ) :: INTEGER AS effective_Gas_Price,
         ingested_at :: TIMESTAMP AS ingested_at,
@@ -54,7 +54,7 @@ WITH base_table AS (
             'traces'
         ) AS tx_json,
         COALESCE(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 tx :receipt :l1Fee :: STRING
             ) :: FLOAT,
             0
@@ -64,13 +64,13 @@ WITH base_table AS (
             0
         ) :: FLOAT AS l1_fee_scalar,
         COALESCE(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 tx :receipt :l1GasPrice :: STRING
             ) :: FLOAT,
             0
         ) AS l1_gas_price,
         COALESCE(
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 tx :receipt :l1GasUsed :: STRING
             ) :: FLOAT,
             0

--- a/models/silver/silver__transfers.sql
+++ b/models/silver/silver__transfers.sql
@@ -70,7 +70,7 @@ find_missing_events AS (
         contract_address :: STRING AS contract_address,
         CONCAT('0x', SUBSTR(topics [1], 27, 40)) :: STRING AS from_address,
         CONCAT('0x', SUBSTR(topics [2], 27, 40)) :: STRING AS to_address,
-        COALESCE(ethereum.public.udf_hex_to_int(topics [3] :: STRING), ethereum.public.udf_hex_to_int(SUBSTR(DATA, 3, 64))) :: FLOAT AS raw_amount,
+        COALESCE(utils.udf_hex_to_int(topics [3] :: STRING), utils.udf_hex_to_int(SUBSTR(DATA, 3, 64))) :: FLOAT AS raw_amount,
         event_index,
         _inserted_timestamp
     FROM

--- a/models/velodrome/silver/silver__velodrome_LP_actions.sql
+++ b/models/velodrome/silver/silver__velodrome_LP_actions.sql
@@ -27,7 +27,7 @@ WITH lp_actions AS (
             WHEN topics [0] :: STRING IN(
                 '0xdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496',
                 '0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f'
-            ) THEN ethereum.public.udf_hex_to_int(
+            ) THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: FLOAT
         END AS amount0_unadj,
@@ -35,7 +35,7 @@ WITH lp_actions AS (
             WHEN topics [0] :: STRING IN(
                 '0xdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496',
                 '0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f'
-            ) THEN ethereum.public.udf_hex_to_int(
+            ) THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: FLOAT
         END AS amount1_unadj,
@@ -47,7 +47,7 @@ WITH lp_actions AS (
         END AS to_address,
         CASE
             WHEN topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' THEN (
-                ethereum.public.udf_hex_to_int(
+                utils.udf_hex_to_int(
                     segmented_data [0] :: STRING
                 ) :: FLOAT / pow(
                     10,

--- a/models/velodrome/silver/silver__velodrome_claimed_rewards.sql
+++ b/models/velodrome/silver/silver__velodrome_claimed_rewards.sql
@@ -17,19 +17,19 @@ WITH velo_distributions AS (
         contract_address,
         event_index,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS token_id,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: FLOAT / pow(
             10,
             18
         ) :: FLOAT AS claimed_amount,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [2] :: STRING
         ) :: INTEGER AS claim_epoch,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [3] :: STRING
         ) :: INTEGER AS max_epoch,
         'venft_distribution' AS reward_type,
@@ -66,7 +66,7 @@ staking_rewards AS (
         contract_address,
         event_index,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS claimed_amount,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,

--- a/models/velodrome/silver/silver__velodrome_locks.sql
+++ b/models/velodrome/silver/silver__velodrome_locks.sql
@@ -19,18 +19,18 @@ WITH new_locks AS (
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS provider_address,
         CASE
-            WHEN topics [0] :: STRING = '0xff04ccafc360e16b67d682d17bd9503c4c6b9a131f6be6325762dc9ffc7de624' THEN TO_TIMESTAMP(ethereum.public.udf_hex_to_int(topics [2] :: STRING))
+            WHEN topics [0] :: STRING = '0xff04ccafc360e16b67d682d17bd9503c4c6b9a131f6be6325762dc9ffc7de624' THEN TO_TIMESTAMP(utils.udf_hex_to_int(topics [2] :: STRING))
             WHEN topics [0] :: STRING = '0x02f25270a4d87bea75db541cdfe559334a275b4a233520ed6c0a2429667cca94' THEN TO_TIMESTAMP(
-                ethereum.public.udf_hex_to_int(
+                utils.udf_hex_to_int(
                     segmented_data [2] :: STRING
                 )
             )
         END AS unlock_date,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS token_id,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: FLOAT / pow(
                 10,
@@ -38,7 +38,7 @@ WITH new_locks AS (
             )
         ) :: FLOAT AS velo_value,
         CASE
-            WHEN topics [0] :: STRING = '0xff04ccafc360e16b67d682d17bd9503c4c6b9a131f6be6325762dc9ffc7de624' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xff04ccafc360e16b67d682d17bd9503c4c6b9a131f6be6325762dc9ffc7de624' THEN utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             )
         END AS deposit_type,

--- a/models/velodrome/silver/silver__velodrome_pools.sql
+++ b/models/velodrome/silver/silver__velodrome_pools.sql
@@ -179,7 +179,7 @@ SELECT
     MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_name,
     MIN(CASE 
             WHEN read_result::STRING = '0x' THEN NULL
-            ELSE ethereum.public.udf_hex_to_int(read_result::STRING)
+            ELSE utils.udf_hex_to_int(read_result::STRING)
         END)::INTEGER  AS pool_decimals,
     MAX(_inserted_timestamp) AS _inserted_timestamp
 FROM details d
@@ -195,7 +195,7 @@ SELECT
     MIN(CASE WHEN function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS token0_symbol,
     MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS token0_name,
     MIN(CASE 
-            WHEN function_name = 'decimals' AND read_result::STRING <> '0x' THEN ethereum.public.udf_hex_to_int(segmented_output [0] :: STRING)
+            WHEN function_name = 'decimals' AND read_result::STRING <> '0x' THEN utils.udf_hex_to_int(segmented_output [0] :: STRING)
             ELSE NULL
         END)::INTEGER AS token0_decimals,
     MAX(_inserted_timestamp) AS _inserted_timestamp
@@ -212,7 +212,7 @@ SELECT
     MIN(CASE WHEN function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS token1_symbol,
     MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS token1_name,
     MIN(CASE 
-            WHEN function_name = 'decimals' AND read_result::STRING <> '0x' THEN ethereum.public.udf_hex_to_int(segmented_output [0] :: STRING)
+            WHEN function_name = 'decimals' AND read_result::STRING <> '0x' THEN utils.udf_hex_to_int(segmented_output [0] :: STRING)
             ELSE NULL
         END)::INTEGER AS token1_decimals,
     MAX(_inserted_timestamp) AS _inserted_timestamp

--- a/models/velodrome/silver/silver__velodrome_staking_actions.sql
+++ b/models/velodrome/silver/silver__velodrome_staking_actions.sql
@@ -21,11 +21,11 @@ WITH staking_actions AS (
             WHEN topics [0] :: STRING = '0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7' THEN 'deposit'
             WHEN topics [0] :: STRING = '0xf341246adaac6f497bc2a656f546ab9e182111d630394f0c57c710a59a2cb567' THEN 'withdraw'
         END AS staking_action_type,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) :: INTEGER AS token_id,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: FLOAT / pow(
                 10,
@@ -66,7 +66,7 @@ token_transfer AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS gauge_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS lp_provider_address,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: FLOAT / pow(
                 10,

--- a/models/velodrome/silver/silver__velodrome_swaps.sql
+++ b/models/velodrome/silver/silver__velodrome_swaps.sql
@@ -23,37 +23,37 @@ WITH base AS (
             WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))
         END AS to_address,
         CASE
-            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: FLOAT
         END AS amount0_in_unadj,
         CASE
-            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: FLOAT
         END AS amount1_in_unadj,
         CASE
-            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN utils.udf_hex_to_int(
                 segmented_data [2] :: STRING
             ) :: FLOAT
         END AS amount0_out_unadj,
         CASE
-            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' THEN utils.udf_hex_to_int(
                 segmented_data [3] :: STRING
             ) :: FLOAT
         END AS amount1_out_unadj,
         CASE
-            WHEN topics [0] :: STRING = '0x112c256902bf554b6ed882d2936687aaeb4225e8cd5b51303c90ca6cf43a8602' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x112c256902bf554b6ed882d2936687aaeb4225e8cd5b51303c90ca6cf43a8602' THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: FLOAT
         END AS fees0_adj,
         CASE
-            WHEN topics [0] :: STRING = '0x112c256902bf554b6ed882d2936687aaeb4225e8cd5b51303c90ca6cf43a8602' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0x112c256902bf554b6ed882d2936687aaeb4225e8cd5b51303c90ca6cf43a8602' THEN utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) :: FLOAT
         END AS fees1_adj,
         CASE
-            WHEN topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' THEN ethereum.public.udf_hex_to_int(
+            WHEN topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' THEN utils.udf_hex_to_int(
                 segmented_data [0] :: STRING
             ) :: FLOAT
         END AS transfer_amount,

--- a/models/velodrome/silver/silver__velodrome_votes.sql
+++ b/models/velodrome/silver/silver__velodrome_votes.sql
@@ -18,11 +18,11 @@ WITH votes_base AS (
         event_index,
         regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
-        ethereum.public.udf_hex_to_int(
+        utils.udf_hex_to_int(
             segmented_data [0] :: STRING
         ) AS token_id,
         (
-            ethereum.public.udf_hex_to_int(
+            utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
             ) / pow(
                 10,


### PR DESCRIPTION
- Update all models using hex_to_int using `public` or `ethereum.public`schema to `utils` schema
- Excludes Sushi model due to future deprecation and `enabled = false`