### PR TITLE
set producer_limit_size, change gha frequency to daily

### DIFF
--- a/.github/workflows/dbt_run_streamline_history.yml
+++ b/.github/workflows/dbt_run_streamline_history.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_streamline_history
 on:
   workflow_dispatch:
   schedule:
-    # Runs "every 16 mins (see https://crontab.guru)
-    - cron: '*/16 * * * *'
+    # Runs at 20:00 UTC (see https://crontab.guru)
+    - cron: '0 20 * * *'
 
 env:
   DBT_PROFILES_DIR: ./

--- a/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
+++ b/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','150000')}}, 'producer_batch_size', {{var('producer_batch_size','150000')}}, 'worker_batch_size', {{var('worker_batch_size','150000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','150000')}},'producer_limit_size', {{var('producer_limit_size','8640000')}}, 'producer_batch_size', {{var('producer_batch_size','150000')}}, 'worker_batch_size', {{var('worker_batch_size','150000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}


### PR DESCRIPTION
- Sets `producer_limit_size = 8640000` for streamline traces history
- Reduces traces history GHA to run at 20:00 UTC daily