### PR TITLE
bumped sql_limit, producer_batch_size & worker_batch_size to meet daily limits

### DIFF
--- a/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
+++ b/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','8640000')}}, 'producer_batch_size', {{var('producer_batch_size','300000')}}, 'worker_batch_size', {{var('worker_batch_size','150000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','12960000')}}, 'producer_batch_size', {{var('producer_batch_size','460000')}}, 'worker_batch_size', {{var('worker_batch_size','230000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}


### PR DESCRIPTION
The `streamline-optimism` `traces history worker` ran out of work to perform for the `8640000` `sql_limit` set up to ingest over a 24 hour window.

This PR increases:

- `sql_limit` to `12960000` for 24 hours based on running out of work in 16 hours for `8640000`
- `worker_batch_size` to `230000` since 2 concurrent worker lambdas reached 75% of memory utilization and `~230k` requests an hour of `360k` QN hourly limit 
- `producer_batch_size` to `460000` in order to get work distributed across 2 worker lambdas
