### PR TITLE
added exploded key and method udf params for non batch traces

### DIFF
--- a/.github/workflows/dbt_run_streamline_history.yml
+++ b/.github/workflows/dbt_run_streamline_history.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     # Runs at minute 0 past every 6th hour. (see https://crontab.guru)
-    - cron: '0 */9 * * *'
+    - cron: '0 */6 * * *'
 
 env:
   DBT_PROFILES_DIR: ./

--- a/.github/workflows/dbt_run_streamline_history.yml
+++ b/.github/workflows/dbt_run_streamline_history.yml
@@ -4,8 +4,8 @@ run-name: dbt_run_streamline_history
 on:
   workflow_dispatch:
   schedule:
-    # Runs at 20:00 UTC (see https://crontab.guru)
-    - cron: '0 20 * * *'
+    # Runs at minute 0 past every 9th hour. (see https://crontab.guru)
+    - cron: '0 */9 * * *'
 
 env:
   DBT_PROFILES_DIR: ./

--- a/.github/workflows/dbt_run_streamline_history.yml
+++ b/.github/workflows/dbt_run_streamline_history.yml
@@ -4,7 +4,7 @@ run-name: dbt_run_streamline_history
 on:
   workflow_dispatch:
   schedule:
-    # Runs at minute 0 past every 9th hour. (see https://crontab.guru)
+    # Runs at minute 0 past every 6th hour. (see https://crontab.guru)
     - cron: '0 */9 * * *'
 
 env:

--- a/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
+++ b/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','12960000')}}, 'producer_batch_size', {{var('producer_batch_size','460000')}}, 'worker_batch_size', {{var('worker_batch_size','230000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}','exploded_key','[\"result\"]', 'method', 'debug_traceBlockByNumber', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','12960000')}}, 'producer_batch_size', {{var('producer_batch_size','460000')}}, 'worker_batch_size', {{var('worker_batch_size','230000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}

--- a/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
+++ b/models/silver/streamline/core/history/streamline__debug_traceBlockByNumber_history.sql
@@ -1,7 +1,7 @@
 {{ config (
     materialized = "view",
     post_hook = if_data_call_function(
-        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}','exploded_key','[\"result\"]', 'method', 'debug_traceBlockByNumber', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','12960000')}}, 'producer_batch_size', {{var('producer_batch_size','460000')}}, 'worker_batch_size', {{var('worker_batch_size','230000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
+        func = "{{this.schema}}.udf_bulk_get_traces(object_construct('sql_source', '{{this.identifier}}','exploded_key','[\"result\"]', 'method', 'debug_traceBlockByNumber', 'external_table', 'debug_traceBlockByNumber', 'sql_limit', {{var('sql_limit','12960000')}}, 'producer_batch_size', {{var('producer_batch_size','920000')}}, 'worker_batch_size', {{var('worker_batch_size','230000')}}, 'batch_call_limit', {{var('batch_call_limit','1')}}))",
         target = "{{this.schema}}.{{this.identifier}}"
     )
 ) }}


### PR DESCRIPTION
- Increases `producer_batch_size` to create 4 concurrent traces worker lambdas to meet the 1k RPS
- Increases frequency of traces GHA runs  