### PR TITLE
An 3947/streamline limits

### DIFF
--- a/models/silver/_observability/silver_observability__blocks_completeness.sql
+++ b/models/silver/_observability/silver_observability__blocks_completeness.sql
@@ -60,10 +60,7 @@ block_range AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT
@@ -105,10 +102,7 @@ block_gen AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT

--- a/models/silver/_observability/silver_observability__logs_completeness.sql
+++ b/models/silver/_observability/silver_observability__logs_completeness.sql
@@ -60,10 +60,7 @@ block_range AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT

--- a/models/silver/_observability/silver_observability__receipts_completeness.sql
+++ b/models/silver/_observability/silver_observability__receipts_completeness.sql
@@ -60,10 +60,7 @@ block_range AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT

--- a/models/silver/_observability/silver_observability__traces_completeness.sql
+++ b/models/silver/_observability/silver_observability__traces_completeness.sql
@@ -60,10 +60,7 @@ block_range AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT

--- a/models/silver/_observability/silver_observability__transactions_completeness.sql
+++ b/models/silver/_observability/silver_observability__transactions_completeness.sql
@@ -60,10 +60,7 @@ block_range AS (
     SELECT
         _id AS block_number
     FROM
-        {{ source(
-            'silver_crosschain',
-            'number_sequence'
-        ) }}
+        {{ ref('silver__number_sequence') }}
     WHERE
         _id BETWEEN (
             SELECT

--- a/models/silver/utilities/silver__number_sequence.sql
+++ b/models/silver/utilities/silver__number_sequence.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized = 'table',
+    cluster_by = 'round(_id,-3)',
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION"
+) }}
+
+SELECT
+    ROW_NUMBER() over (
+        ORDER BY
+            SEQ4()
+    ) - 1 :: INT AS _id
+FROM
+    TABLE(GENERATOR(rowcount => 500000001))

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -33,7 +33,6 @@ sources:
       - name: token_prices_all_providers_hourly
       - name: asset_metadata_priority
       - name: asset_metadata_all_providers
-      - name: number_sequence
   - name: streamline_crosschain
     database: streamline
     schema: crosschain

--- a/models/streamline/silver/_block_lookback.sql
+++ b/models/streamline/silver/_block_lookback.sql
@@ -1,0 +1,11 @@
+{{ config (
+    materialized = "ephemeral"
+) }}
+
+SELECT
+    MIN(block_number) AS block_number
+FROM
+    {{ ref("silver__blocks") }}
+WHERE
+    block_timestamp >= DATEADD('hour', -72, TRUNCATE(SYSDATE(), 'HOUR'))
+    AND block_timestamp < DATEADD('hour', -71, TRUNCATE(SYSDATE(), 'HOUR'))

--- a/models/streamline/silver/core/realtime/streamline__confirm_blocks_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__confirm_blocks_realtime.sql
@@ -44,6 +44,11 @@ tbl AS (
             FROM
                 look_back
         )
+        AND _inserted_timestamp >= DATEADD(
+            'day',
+            -4,
+            SYSDATE()
+        )
 )
 SELECT
     PARSE_JSON(
@@ -71,3 +76,5 @@ FROM
     tbl
 ORDER BY
     block_number ASC
+LIMIT
+    3600

--- a/models/streamline/silver/core/realtime/streamline__confirm_blocks_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__confirm_blocks_realtime.sql
@@ -7,8 +7,14 @@
     tags = ['streamline_core_realtime']
 ) }}
 
-WITH look_back AS (
+WITH last_3_days AS (
 
+    SELECT
+        block_number
+    FROM
+        {{ ref("_block_lookback") }}
+),
+look_back AS (
     SELECT
         block_number
     FROM
@@ -31,6 +37,12 @@ tbl AS (
             FROM
                 look_back
         )
+        AND block_number >= (
+            SELECT
+                block_number
+            FROM
+                last_3_days
+        )
     EXCEPT
     SELECT
         block_number
@@ -48,6 +60,12 @@ tbl AS (
             'day',
             -4,
             SYSDATE()
+        )
+        AND block_number >= (
+            SELECT
+                block_number
+            FROM
+                last_3_days
         )
 )
 SELECT

--- a/models/streamline/silver/core/realtime/streamline__debug_traceBlockByNumber_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__debug_traceBlockByNumber_realtime.sql
@@ -46,6 +46,11 @@ blocks AS (
                     last_3_days
             )
         )
+        AND _inserted_timestamp >= DATEADD(
+            'day',
+            -4,
+            SYSDATE()
+        )
 ),
 all_blocks AS (
     SELECT
@@ -95,3 +100,5 @@ FROM
     all_blocks
 ORDER BY
     block_number ASC
+LIMIT
+    1800

--- a/models/streamline/silver/core/realtime/streamline__debug_traceBlockByNumber_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__debug_traceBlockByNumber_realtime.sql
@@ -12,11 +12,7 @@ WITH last_3_days AS (
     SELECT
         block_number
     FROM
-        {{ ref("_max_block_by_date") }}
-        qualify ROW_NUMBER() over (
-            ORDER BY
-                block_number DESC
-        ) = 3
+        {{ ref("_block_lookback") }}
 ),
 blocks AS (
     SELECT

--- a/models/streamline/silver/core/realtime/streamline__qn_getBlockWithReceipts_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__qn_getBlockWithReceipts_realtime.sql
@@ -12,11 +12,7 @@ WITH last_3_days AS (
     SELECT
         block_number
     FROM
-        {{ ref("_max_block_by_date") }}
-        qualify ROW_NUMBER() over (
-            ORDER BY
-                block_number DESC
-        ) = 3
+        {{ ref("_block_lookback") }}
 ),
 blocks AS (
     SELECT

--- a/models/streamline/silver/core/realtime/streamline__qn_getBlockWithReceipts_realtime.sql
+++ b/models/streamline/silver/core/realtime/streamline__qn_getBlockWithReceipts_realtime.sql
@@ -46,6 +46,11 @@ blocks AS (
                     last_3_days
             )
         )
+        AND _inserted_timestamp >= DATEADD(
+            'day',
+            -4,
+            SYSDATE()
+        )
 ),
 all_blocks AS (
     SELECT
@@ -99,3 +104,5 @@ FROM
     all_blocks
 ORDER BY
     block_number ASC
+LIMIT
+    1800

--- a/models/streamline/silver/core/retry/_missing_receipts.sql
+++ b/models/streamline/silver/core/retry/_missing_receipts.sql
@@ -5,27 +5,28 @@
 WITH lookback AS (
 
     SELECT
-        MAX(block_number) AS block_number
+        block_number
     FROM
-        {{ ref("silver__blocks") }}
-    WHERE
-        block_timestamp >= DATEADD('hour', -48, SYSDATE()))
-    SELECT
-        DISTINCT t.block_number AS block_number
-    FROM
-        {{ ref("silver__transactions") }}
-        t
-        LEFT JOIN {{ ref("silver__receipts") }}
-        r USING (
-            block_number,
-            block_hash,
-            tx_hash
-        )
-    WHERE
-        r.tx_hash IS NULL
-        AND t.block_number >= (
-            SELECT
-                block_number
-            FROM
-                lookback
-        )
+        {{ ref("_block_lookback") }}
+)
+SELECT
+    DISTINCT t.block_number AS block_number
+FROM
+    {{ ref("silver__transactions") }}
+    t
+    LEFT JOIN {{ ref("silver__receipts") }}
+    r USING (
+        block_number,
+        block_hash,
+        tx_hash
+    )
+WHERE
+    r.tx_hash IS NULL
+    AND t.block_number >= (
+        SELECT
+            block_number
+        FROM
+            lookback
+    )
+    AND t.block_timestamp >= DATEADD('hour', -84, SYSDATE())
+    AND r._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())

--- a/models/streamline/silver/core/retry/_missing_receipts.sql
+++ b/models/streamline/silver/core/retry/_missing_receipts.sql
@@ -9,7 +9,7 @@ WITH lookback AS (
     FROM
         {{ ref("silver__blocks") }}
     WHERE
-        block_timestamp >= DATEADD('hour', -24, SYSDATE()))
+        block_timestamp >= DATEADD('hour', -48, SYSDATE()))
     SELECT
         DISTINCT t.block_number AS block_number
     FROM

--- a/models/streamline/silver/core/retry/_missing_receipts.sql
+++ b/models/streamline/silver/core/retry/_missing_receipts.sql
@@ -9,24 +9,23 @@ WITH lookback AS (
     FROM
         {{ ref("silver__blocks") }}
     WHERE
-        block_timestamp :: DATE = CURRENT_DATE() - 3
-)
-SELECT
-    DISTINCT t.block_number AS block_number
-FROM
-    {{ ref("silver__transactions") }}
-    t
-    LEFT JOIN {{ ref("silver__receipts") }}
-    r USING (
-        block_number,
-        block_hash,
-        tx_hash
-    )
-WHERE
-    r.tx_hash IS NULL
-    AND t.block_number >= (
-        SELECT
-            block_number
-        FROM
-            lookback
-    )
+        block_timestamp >= DATEADD('hour', -24, SYSDATE()))
+    SELECT
+        DISTINCT t.block_number AS block_number
+    FROM
+        {{ ref("silver__transactions") }}
+        t
+        LEFT JOIN {{ ref("silver__receipts") }}
+        r USING (
+            block_number,
+            block_hash,
+            tx_hash
+        )
+    WHERE
+        r.tx_hash IS NULL
+        AND t.block_number >= (
+            SELECT
+                block_number
+            FROM
+                lookback
+        )

--- a/models/streamline/silver/core/retry/_missing_traces.sql
+++ b/models/streamline/silver/core/retry/_missing_traces.sql
@@ -2,6 +2,13 @@
     materialized = "ephemeral"
 ) }}
 
+WITH lookback AS (
+
+    SELECT
+        block_number
+    FROM
+        {{ ref("_block_lookback") }}
+)
 SELECT
     DISTINCT tx.block_number block_number
 FROM
@@ -11,7 +18,13 @@ FROM
     tr
     ON tx.block_number = tr.block_number
     AND tx.tx_hash = tr.tx_hash
-    AND tr.block_timestamp >= DATEADD('hour', -48, SYSDATE())
+    AND tr.block_timestamp >= DATEADD('hour', -84, SYSDATE())
 WHERE
-    tx.block_timestamp >= DATEADD('hour', -48, SYSDATE())
+    tx.block_timestamp >= DATEADD('hour', -84, SYSDATE())
     AND tr.tx_hash IS NULL
+    AND tx.block_number >= (
+        SELECT
+            block_number
+        FROM
+            lookback
+    )

--- a/models/streamline/silver/core/retry/_missing_traces.sql
+++ b/models/streamline/silver/core/retry/_missing_traces.sql
@@ -11,15 +11,7 @@ FROM
     tr
     ON tx.block_number = tr.block_number
     AND tx.tx_hash = tr.tx_hash
-    AND tr.block_timestamp >= DATEADD(
-        'day',
-        -2,
-        CURRENT_DATE
-    )
+    AND tr.block_timestamp >= DATEADD('hour', -24, SYSDATE())
 WHERE
-    tx.block_timestamp >= DATEADD(
-        'day',
-        -2,
-        CURRENT_DATE
-    )
+    tx.block_timestamp >= DATEADD('hour', -24, SYSDATE())
     AND tr.tx_hash IS NULL

--- a/models/streamline/silver/core/retry/_missing_traces.sql
+++ b/models/streamline/silver/core/retry/_missing_traces.sql
@@ -11,7 +11,7 @@ FROM
     tr
     ON tx.block_number = tr.block_number
     AND tx.tx_hash = tr.tx_hash
-    AND tr.block_timestamp >= DATEADD('hour', -24, SYSDATE())
+    AND tr.block_timestamp >= DATEADD('hour', -48, SYSDATE())
 WHERE
-    tx.block_timestamp >= DATEADD('hour', -24, SYSDATE())
+    tx.block_timestamp >= DATEADD('hour', -48, SYSDATE())
     AND tr.tx_hash IS NULL

--- a/models/streamline/silver/core/retry/_missing_txs.sql
+++ b/models/streamline/silver/core/retry/_missing_txs.sql
@@ -18,15 +18,10 @@ WITH transactions AS (
     FROM
         {{ ref("silver__transactions") }}
     WHERE
-        block_timestamp >= DATEADD(
-            'day',
-            -2,
-            CURRENT_DATE
-        )
-)
-SELECT
-    DISTINCT block_number AS block_number
-FROM
-    transactions
-WHERE
-    POSITION - prev_POSITION <> 1
+        block_timestamp >= DATEADD('hour', -24, SYSDATE()))
+    SELECT
+        DISTINCT block_number AS block_number
+    FROM
+        transactions
+    WHERE
+        POSITION - prev_POSITION <> 1

--- a/models/streamline/silver/core/retry/_missing_txs.sql
+++ b/models/streamline/silver/core/retry/_missing_txs.sql
@@ -18,7 +18,7 @@ WITH transactions AS (
     FROM
         {{ ref("silver__transactions") }}
     WHERE
-        block_timestamp >= DATEADD('hour', -24, SYSDATE()))
+        block_timestamp >= DATEADD('hour', -48, SYSDATE()))
     SELECT
         DISTINCT block_number AS block_number
     FROM

--- a/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
+++ b/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
@@ -5,27 +5,26 @@
 WITH lookback AS (
 
     SELECT
-        MAX(block_number) AS block_number
+        block_number
     FROM
-        {{ ref("silver__blocks") }}
-    WHERE
-        block_timestamp >= DATEADD('hour', -72, SYSDATE()))
-    SELECT
-        DISTINCT cb.block_number AS block_number
-    FROM
-        {{ ref("silver__confirmed_blocks") }}
-        cb
-        LEFT JOIN {{ ref("silver__transactions") }}
-        txs USING (
-            block_number,
-            block_hash,
-            tx_hash
-        )
-    WHERE
-        txs.tx_hash IS NULL
-        AND cb.block_number >= (
-            SELECT
-                block_number
-            FROM
-                lookback
-        )
+        {{ ref("_block_lookback") }}
+)
+SELECT
+    DISTINCT cb.block_number AS block_number
+FROM
+    {{ ref("silver__confirmed_blocks") }}
+    cb
+    LEFT JOIN {{ ref("silver__transactions") }}
+    txs USING (
+        block_number,
+        block_hash,
+        tx_hash
+    )
+WHERE
+    txs.tx_hash IS NULL
+    AND cb.block_number >= (
+        SELECT
+            block_number
+        FROM
+            lookback
+    )

--- a/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
+++ b/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
@@ -28,3 +28,5 @@ WHERE
         FROM
             lookback
     )
+    AND cb._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())
+    AND txs._inserted_timestamp >= DATEADD('hour', -84, SYSDATE())

--- a/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
+++ b/models/streamline/silver/core/retry/_unconfirmed_blocks.sql
@@ -9,24 +9,23 @@ WITH lookback AS (
     FROM
         {{ ref("silver__blocks") }}
     WHERE
-        block_timestamp :: DATE = CURRENT_DATE() - 3
-)
-SELECT
-    DISTINCT cb.block_number AS block_number
-FROM
-    {{ ref("silver__confirmed_blocks") }}
-    cb
-    LEFT JOIN {{ ref("silver__transactions") }}
-    txs USING (
-        block_number,
-        block_hash,
-        tx_hash
-    )
-WHERE
-    txs.tx_hash IS NULL
-    AND cb.block_number >= (
-        SELECT
-            block_number
-        FROM
-            lookback
-    )
+        block_timestamp >= DATEADD('hour', -72, SYSDATE()))
+    SELECT
+        DISTINCT cb.block_number AS block_number
+    FROM
+        {{ ref("silver__confirmed_blocks") }}
+        cb
+        LEFT JOIN {{ ref("silver__transactions") }}
+        txs USING (
+            block_number,
+            block_hash,
+            tx_hash
+        )
+    WHERE
+        txs.tx_hash IS NULL
+        AND cb.block_number >= (
+            SELECT
+                block_number
+            FROM
+                lookback
+        )

--- a/models/streamline/silver/core/streamline__blocks.sql
+++ b/models/streamline/silver/core/streamline__blocks.sql
@@ -3,15 +3,18 @@
     tags = ['streamline_core_complete']
 ) }}
 
-
 {% if execute %}
-{% set height = run_query('SELECT streamline.udf_get_chainhead()') %}
-{% set block_height = height.columns[0].values()[0] %}
+    {% set height = run_query('SELECT streamline.udf_get_chainhead()') %}
+    {% set block_height = height.columns [0].values() [0] %}
 {% else %}
-{% set block_height = 0 %}
+    {% set block_height = 0 %}
 {% endif %}
 
 SELECT
-    height as block_number
+    _id AS block_number
 FROM
-    TABLE(streamline.udtf_get_base_table({{block_height}}))
+    {{ ref("silver__number_sequence") }}
+WHERE
+    _id <= {{ block_height }}
+ORDER BY
+    _id ASC


### PR DESCRIPTION
- adds one hour blocks limit to streamline models
- modifies `streamline__blocks` to select from generated table instead of creating rows each time
- shortens retry logic look back to 24 hours from `sysdate()` 
- uses `_block_Lookback` ephemeral model to get three day lookback instead of looking at every date 
- removes cross db join for sequence