### PR TITLE
AN-3973/delete-insert-reorg

### DIFF
--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -49,5 +49,5 @@ jobs:
   
       - name: Execute block_reorg macro
         run: |
-          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && awk '/SQL status/ {print; next} /DELETE FROM/{getline; print} /\/\* {/ {print}' logs/dbt.log
         

--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -1,0 +1,53 @@
+name: dbt_run_operation_reorg
+run-name: dbt_run_operation_reorg
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 50 every 8 hours (see https://crontab.guru)
+    - cron: '50 */8 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: List reorg models
+        id: list_models
+        run: |
+          reorg_model_list=$(dbt list --select tag:reorg --resource-type model | awk -F'.' '{print $NF}' | tr '\n' ',' | sed 's/,$//')
+          echo "::set-output name=model_list::$reorg_model_list"
+  
+      - name: Execute block_reorg macro
+        run: |
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
+        

--- a/models/bronze/ethereum/bronze__state_hashes.sql
+++ b/models/bronze/ethereum/bronze__state_hashes.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "state_tx_hash",
+    incremental_strategy = 'delete+insert',
+    unique_key = "state_block_number",
     tags = ['ethereum','non_realtime']
 ) }}
 

--- a/models/bronze/ethereum/bronze__submission_hashes.sql
+++ b/models/bronze/ethereum/bronze__submission_hashes.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "l1_submission_tx_hash",
+    incremental_strategy = 'delete+insert',
+    unique_key = "l1_submission_block_number",
     tags = ['ethereum','non_realtime']
 ) }}
 

--- a/models/gold/core/core__ez_eth_transfers.sql
+++ b/models/gold/core/core__ez_eth_transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }

--- a/models/gold/core/core__ez_eth_transfers.sql
+++ b/models/gold/core/core__ez_eth_transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['core','non_realtime'],
+    tags = ['core','non_realtime','reorg'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,7 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     full_refresh = false,
     tags = ['decoded_logs']
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,11 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
-    tags = ['decoded_logs']
+    tags = ['decoded_logs','reorg']
 ) }}
 
 WITH base_data AS (

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,8 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
+
 ) }}
 
 WITH logs AS (

--- a/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_pools.sql
+++ b/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_pools.sql
@@ -1,10 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
-
---    full_refresh = false
 
 WITH pools_registered AS (
 
@@ -27,7 +27,7 @@ WITH pools_registered AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_swaps.sql
+++ b/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_swaps.sql
+++ b/models/silver/defi/dex/beethovenx/silver_dex__beethovenx_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -55,7 +58,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -1,9 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
---    full_refresh = false,
 
 WITH contract_deployments AS (
 
@@ -30,7 +31,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pool_meta AS (
@@ -72,7 +75,7 @@ curve_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -119,7 +122,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -28,7 +29,7 @@ WITH pool_tr AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -75,7 +76,7 @@ pool_evt AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -91,7 +94,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/frax/silver_dex__fraxswap_pools.sql
+++ b/models/silver/defi/dex/frax/silver_dex__fraxswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/frax/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/defi/dex/frax/silver_dex__fraxswap_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -62,7 +65,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/frax/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/defi/dex/frax/silver_dex__fraxswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -27,7 +28,7 @@ WITH contract_deployments AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -70,7 +73,7 @@ router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -134,7 +137,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -67,7 +70,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -80,7 +83,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -3,9 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
-
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -27,7 +28,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -53,7 +56,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/synthetix/silver_dex__synthetix_swaps.sql
+++ b/models/silver/defi/dex/synthetix/silver_dex__synthetix_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH swaps_base AS (
@@ -46,7 +49,7 @@ WITH swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/synthetix/silver_dex__synthetix_swaps.sql
+++ b/models/silver/defi/dex/synthetix/silver_dex__synthetix_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -37,7 +38,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -65,7 +66,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 2
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH base_swaps AS (
@@ -45,7 +48,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_pools.sql
+++ b/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -36,7 +37,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_swaps.sql
+++ b/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH pools AS (
@@ -64,7 +67,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_swaps.sql
+++ b/models/silver/defi/dex/velodrome/silver_dex__velodrome_v2_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH router_swaps_base AS (
@@ -65,7 +68,7 @@ WITH router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -129,7 +132,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/ethereum/silver__state_hashes.sql
+++ b/models/silver/ethereum/silver__state_hashes.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['state_block_timestamp::DATE'],
     tags = ['ethereum','non_realtime']

--- a/models/silver/ethereum/silver__submission_hashes.sql
+++ b/models/silver/ethereum/silver__submission_hashes.sql
@@ -1,5 +1,6 @@
 {{ config(
     materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['l1_submission_block_timestamp::DATE'],
     tags = ['ethereum','non_realtime']

--- a/models/silver/governance/silver__delegations.sql
+++ b/models/silver/governance/silver__delegations.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['non_realtime']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__quix_sales.sql
+++ b/models/silver/nft/silver__quix_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
     tags = ['stale']
 ) }}

--- a/models/silver/nft/silver__quix_seaport_sales.sql
+++ b/models/silver/nft/silver__quix_seaport_sales.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH seaport_fees_wallet AS (
@@ -31,7 +34,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -74,7 +77,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1049,7 +1052,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1086,7 +1089,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__quix_seaport_sales.sql
+++ b/models/silver/nft/silver__quix_seaport_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
     tags = ['stale']
 ) }}
@@ -33,7 +34,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -76,7 +77,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1053,7 +1054,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1096,7 +1097,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH seaport_fees_wallet AS (
@@ -32,7 +35,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -92,7 +95,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1658,7 +1661,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1701,7 +1704,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH seaport_fees_wallet AS (
@@ -32,7 +35,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -92,7 +95,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1658,7 +1661,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1701,7 +1704,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -31,7 +31,7 @@ AND p._inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/protocols/velodrome/silver__velodrome_LP_actions.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_LP_actions.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH lp_actions AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_LP_actions.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_LP_actions.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_claimed_rewards.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_claimed_rewards.sql
@@ -1,8 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
+
 ) }}
 
 WITH velo_distributions AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_claimed_rewards.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_claimed_rewards.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_gauges.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_gauges.sql
@@ -1,6 +1,8 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'gauge_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_gauges.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_gauges.sql
@@ -2,8 +2,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH backfill AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_locks.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_locks.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH new_locks AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_locks.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_locks.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_pool_details.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_pool_details.sql
@@ -1,6 +1,8 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -34,13 +36,13 @@ FROM
 WHERE
     p._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) :: DATE - 1
+            MAX(_inserted_timestamp) - INTERVAL '12 hours'
         FROM
             {{ this }}
     )
     AND l._inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) :: DATE - 1
+            MAX(_inserted_timestamp) - INTERVAL '12 hours'
         FROM
             {{ this }}
     )

--- a/models/silver/protocols/velodrome/silver__velodrome_pool_details.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_pool_details.sql
@@ -2,8 +2,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 SELECT

--- a/models/silver/protocols/velodrome/silver__velodrome_pools.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_pools.sql
@@ -1,8 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
+    unique_key = 'created_block',
     tags = ['non_realtime'],
     full_refresh = false
 ) }}

--- a/models/silver/protocols/velodrome/silver__velodrome_pools.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_pools.sql
@@ -1,6 +1,8 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime'],
     full_refresh = false
 ) }}

--- a/models/silver/protocols/velodrome/silver__velodrome_staking_actions.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_staking_actions.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH staking_actions AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_staking_actions.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_staking_actions.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_swaps.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_swaps.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/protocols/velodrome/silver__velodrome_votes.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_votes.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH votes_base AS (

--- a/models/silver/protocols/velodrome/silver__velodrome_votes.sql
+++ b/models/silver/protocols/velodrome/silver__velodrome_votes.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.0
+    revision: v1.6.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.5.0
+    revision: v1.6.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.1
+    revision: v1.6.2
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12-24 hrs vs 1-3 days, with exceptions
3. FR required on complete_dex_swaps, complete_dex_liquidity_pools to add `version` columns
4. Adds new workflow for block reorg macro, scheduled to run 3x daily - based on `reorg` tag