### PR TITLE
add/decoder-history-range

### DIFF
--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0123571367_0124371367.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0123571367_0124371367.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0124371368_0125171368.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0124371368_0125171368.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0125171369_0125971369.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0125171369_0125971369.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0125971370_0126771370.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0125971370_0126771370.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0126771371_0127571371.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0126771371_0127571371.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0127571372_0128371372.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0127571372_0128371372.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0128371373_0129171373.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0128371373_0129171373.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0129171374_0129971374.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0129171374_0129971374.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0129971375_0130771375.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0129971375_0130771375.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0130771376_0131571376.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0130771376_0131571376.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0131571377_0132371377.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0131571377_0132371377.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0132371378_0133171378.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0132371378_0133171378.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0133171379_0133971379.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0133171379_0133971379.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0133971380_0134771380.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0133971380_0134771380.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0134771381_0135571381.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0134771381_0135571381.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0135571382_0136371382.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0135571382_0136371382.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0136371383_0137171383.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0136371383_0137171383.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0137171384_0137971384.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0137171384_0137971384.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0137971385_0138771385.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0137971385_0138771385.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0138771386_0139571386.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0138771386_0139571386.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0139571387_0140371387.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0139571387_0140371387.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0140371388_0141171388.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0140371388_0141171388.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0141171389_0141971389.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0141171389_0141971389.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0141971390_0142771390.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0141971390_0142771390.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0142771391_0143571391.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0142771391_0143571391.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0143571392_0144371392.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0143571392_0144371392.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0144371393_0145171393.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0144371393_0145171393.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0145171394_0145971394.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0145171394_0145971394.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0145971395_0146771395.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0145971395_0146771395.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0146771396_0147571396.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0146771396_0147571396.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0147571397_0148371397.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0147571397_0148371397.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0148371398_0149171398.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0148371398_0149171398.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0149171399_0149971399.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0149171399_0149971399.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0149971400_0150771400.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0149971400_0150771400.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0150771401_0151571401.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0150771401_0151571401.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0151571402_0152371402.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0151571402_0152371402.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0152371403_0153171403.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0152371403_0153171403.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0153171404_0153971404.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0153171404_0153971404.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0153971405_0154771405.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0153971405_0154771405.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0154771406_0155571406.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0154771406_0155571406.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0155571407_0156371407.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0155571407_0156371407.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0156371408_0157171408.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0156371408_0157171408.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0157171409_0157971409.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0157171409_0157971409.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0157971410_0158771410.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0157971410_0158771410.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0158771411_0159571411.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0158771411_0159571411.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0159571412_0160371412.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0159571412_0160371412.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0160371413_0161171413.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0160371413_0161171413.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0161171414_0161971414.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0161171414_0161971414.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0161971415_0162771415.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0161971415_0162771415.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0162771416_0163571416.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0162771416_0163571416.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0163571417_0164371417.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0163571417_0164371417.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0164371418_0165171418.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0164371418_0165171418.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0165171419_0165971419.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0165171419_0165971419.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0165971420_0166771420.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0165971420_0166771420.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0166771421_0167571421.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0166771421_0167571421.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0167571422_0168371422.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0167571422_0168371422.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0168371423_0169171423.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0168371423_0169171423.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0169171424_0169971424.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0169171424_0169971424.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0169971425_0170771425.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0169971425_0170771425.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0170771426_0171571426.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0170771426_0171571426.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0171571427_0172371427.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0171571427_0172371427.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0172371428_0173171428.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0172371428_0173171428.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0173171429_0173971429.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0173171429_0173971429.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0173971430_0174771430.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0173971430_0174771430.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0174771431_0175571431.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0174771431_0175571431.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0175571432_0176371432.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0175571432_0176371432.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0176371433_0177171433.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0176371433_0177171433.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0177171434_0177971434.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0177171434_0177971434.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0177971435_0178771435.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0177971435_0178771435.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0178771436_0179571436.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0178771436_0179571436.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0179571437_0180371437.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0179571437_0180371437.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0180371438_0181171438.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0180371438_0181171438.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0181171439_0181971439.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0181171439_0181971439.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0181971440_0182771440.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0181971440_0182771440.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0182771441_0183571441.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0182771441_0183571441.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0183571442_0184371442.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0183571442_0184371442.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0184371443_0185171443.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0184371443_0185171443.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0185171444_0185971444.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0185171444_0185971444.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0185971445_0186771445.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0185971445_0186771445.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0186771446_0187571446.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0186771446_0187571446.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0187571447_0188371447.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0187571447_0188371447.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0188371448_0189171448.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0188371448_0189171448.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0189171449_0189971449.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0189171449_0189971449.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0189971450_0190771450.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0189971450_0190771450.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}

--- a/models/streamline/silver/decoder/history/streamline__decode_logs_history_0190771451_0191571451.sql
+++ b/models/streamline/silver/decoder/history/streamline__decode_logs_history_0190771451_0191571451.sql
@@ -1,0 +1,12 @@
+{{ config (
+    materialized = "view",
+    post_hook = [if_data_call_function( func = "{{model.schema}}.udf_bulk_decode_logs(object_construct('sql_source', '{{model.alias}}','producer_batch_size', 20000000,'producer_limit_size', {{var('row_limit',7500000)}}))", target = "{{model.schema}}.{{model.alias}}" ) ,if_data_call_wait()],
+    tags = ['streamline_decoded_logs_history']
+) }}
+
+{% set start = this.identifier.split("_") [-2] %}
+{% set stop = this.identifier.split("_") [-1] %}
+{{ fsc_utils.decode_logs_history(
+    start,
+    stop
+) }}


### PR DESCRIPTION
 Requires `dbt run -m models/streamline/silver/decoder/history --full-refresh` + run history job