### PR TITLE
AN-4451/new-bridges

### DIFF
--- a/models/doc_descriptions/bridge/evm_bridge_activity.md
+++ b/models/doc_descriptions/bridge/evm_bridge_activity.md
@@ -1,6 +1,6 @@
 {% docs evm_bridge_table_doc %}
 
-A convenience table that aggregates bridge activity from event_logs, traces and transfers, including bridge deposits and transfers sent from the following protocols: ACROSS, AXELAR, CELER, CBRIDGE, HOP, MESON, MULTICHAIN, STARGATE, SYMBIOSIS, SYNAPSE, WORMHOLE along with other helpful columns, including an amount USD where available. Note, this table only includes records for the protocols listed above with live, onchain bridge activity and may not represent the complete bridging picture.
+A convenience table that aggregates bridge activity from event_logs, traces and transfers, including bridge deposits and transfers sent from the following protocols: ACROSS, AXELAR, CELER, CBRIDGE, DLN, DEBRIDGE, EYWA, HOP, MESON, MULTICHAIN, STARGATE, SYMBIOSIS, SYNAPSE, WORMHOLE along with other helpful columns, including an amount USD where available. Note, this table only includes records for the protocols listed above with live, onchain bridge activity and may not represent the complete bridging picture.
 
 {% enddocs %}
 

--- a/models/gold/defi/defi__ez_bridge_activity.sql
+++ b/models/gold/defi/defi__ez_bridge_activity.sql
@@ -5,7 +5,7 @@
     meta ={ 
         'database_tags':{
             'table':{
-                'PROTOCOL': 'ACROSS, AXELAR, CELER, CBRIDGE, HOP, MESON, MULTICHAIN, STARGATE, SYMBIOSIS, SYNAPSE, WORMHOLE',
+                'PROTOCOL': 'ACROSS, AXELAR, CELER, CBRIDGE, DLN, DEBRIDGE, EYWA, HOP, MESON, MULTICHAIN, STARGATE, SYMBIOSIS, SYNAPSE, WORMHOLE',
                 'PURPOSE': 'BRIDGE'
         } } }
 ) }}

--- a/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql
+++ b/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH base_evt AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'dln_debridge' AS NAME,
+        event_index,
+        topics [0] :: STRING AS topic_0,
+        event_name,
+        decoded_flat :"affiliateFee" :: STRING AS affiliateFee,
+        decoded_flat :"metadata" :: STRING AS metadata,
+        TRY_TO_NUMBER(
+            decoded_flat :"nativeFixFee" :: STRING
+        ) AS nativeFixFee,
+        decoded_flat :"order" AS order_obj,
+        decoded_flat :"order" :"allowedCancelBeneficiarySrc" :: STRING AS allowedCancelBeneficiarySrc,
+        decoded_flat :"order" :"allowedTakerDst" :: STRING AS allowedTakerDst,
+        decoded_flat :"order" :"externalCall" :: STRING AS externalCall,
+        TRY_TO_NUMBER(
+            decoded_flat :"order" :"giveAmount" :: STRING
+        ) AS giveAmount,
+        TRY_TO_NUMBER(
+            decoded_flat :"order" :"giveChainId" :: STRING
+        ) AS giveChainId,
+        decoded_flat :"order" :"givePatchAuthoritySrc" :: STRING AS givePatchAuthoritySrc,
+        decoded_flat :"order" :"giveTokenAddress" :: STRING AS giveTokenAddress,
+        TRY_TO_NUMBER(
+            decoded_flat :"order" :"makerOrderNonce" :: STRING
+        ) AS makerOrderNonce,
+        decoded_flat :"order" :"makerSrc" :: STRING AS makerSrc,
+        decoded_flat :"order" :"orderAuthorityAddressDst" :: STRING AS orderAuthorityAddressDst,
+        decoded_flat :"order" :"receiverDst" :: STRING AS receiverDst,
+        TRY_TO_NUMBER(
+            decoded_flat :"order" :"takeAmount" :: STRING
+        ) AS takeAmount,
+        TRY_TO_NUMBER(
+            decoded_flat :"order" :"takeChainId" :: STRING
+        ) AS takeChainId,
+        decoded_flat :"order" :"takeTokenAddress" :: STRING AS takeTokenAddress,
+        decoded_flat :"orderId" :: STRING AS orderId,
+        TRY_TO_NUMBER(
+            decoded_flat :"percentFee" :: STRING
+        ) AS percentFee,
+        TRY_TO_NUMBER(
+            decoded_flat :"referralCode" :: STRING
+        ) AS referralCode,
+        decoded_flat,
+        event_removed,
+        tx_status,
+        DATA,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(segmented_data [24] :: STRING, 1, 40)) AS token_address,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_logs') }}
+    WHERE
+        topics [0] :: STRING = '0xfc8703fd57380f9dd234a89dce51333782d49c5902f307b02f03e014d18fe471' --CreatedOrder
+        AND contract_address = '0xef4fb24ad0916217251f553c0596f8edc630eb66' --Dln: Source
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    topic_0,
+    event_name,
+    event_removed,
+    tx_status,
+    contract_address AS bridge_address,
+    NAME AS platform,
+    origin_from_address AS sender,
+    sender AS receiver,
+    receiver AS destination_chain_receiver,
+    giveAmount AS amount,
+    takeChainId AS destination_chain_id,
+    CASE
+        WHEN destination_chain_id :: STRING = '7565164' THEN 'solana'
+        ELSE NULL
+    END AS destination_chain,
+    CASE
+        WHEN token_address = '0x0000000000000000000000000000000000000000' THEN '0x4200000000000000000000000000000000000006'
+        ELSE token_address
+    END AS token_address,
+    decoded_flat,
+    order_obj,
+    _log_id,
+    _inserted_timestamp
+FROM
+    base_evt

--- a/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.yml
+++ b/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.yml
@@ -1,0 +1,74 @@
+version: 2
+models:
+  - name: silver_bridge__dln_debridge_createdorder
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: EVENT_NAME
+        tests:
+          - not_null
+      - name: BRIDGE_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: RECEIVER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: DESTINATION_CHAIN_RECEIVER
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3

--- a/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.sql
+++ b/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.sql
@@ -1,0 +1,137 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH base_evt AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'eywa' AS NAME,
+        event_index,
+        topics [0] :: STRING AS topic_0,
+        event_name,
+        decoded_flat,
+        event_removed,
+        tx_status,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_logs') }}
+    WHERE
+        topics [0] :: STRING IN (
+            '0x5566d73d091d945ab32ea023cd1930c0d43aa43bef9aee4cb029775cfc94bdae',
+            --RequestSent
+            '0xb5f411fa3c897c9b0b6cd61852278a67e73d885610724a5610a8580d3e94cfdb'
+        ) --locked
+        AND contract_address IN (
+            '0xece9cf6a8f2768a3b8b65060925b646afeaa5167',
+            --BridgeV2
+            '0xac8f44ceca92b2a4b30360e5bd3043850a0ffcbe',
+            --PortalV2
+            '0xbf0b5d561b986809924f88099c4ff0e6bcce60c9' --PortalV2
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+requestsent AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        NAME,
+        event_index,
+        topic_0,
+        event_name,
+        decoded_flat :"chainIdTo" :: STRING AS chainIdTo,
+        decoded_flat :"data" :: STRING AS data_requestsent,
+        decoded_flat :"requestId" :: STRING AS requestId,
+        decoded_flat :"to" :: STRING AS to_address,
+        decoded_flat,
+        event_removed,
+        tx_status,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        base_evt
+    WHERE
+        topic_0 = '0x5566d73d091d945ab32ea023cd1930c0d43aa43bef9aee4cb029775cfc94bdae' --RequestSent
+),
+locked AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        NAME,
+        event_index,
+        topic_0,
+        event_name,
+        TRY_TO_NUMBER(
+            decoded_flat :"amount" :: STRING
+        ) AS amount,
+        decoded_flat :"from" :: STRING AS from_address,
+        decoded_flat :"to" :: STRING AS to_address,
+        decoded_flat :"token" :: STRING AS token,
+        decoded_flat,
+        event_removed,
+        tx_status,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        base_evt
+    WHERE
+        topic_0 = '0xb5f411fa3c897c9b0b6cd61852278a67e73d885610724a5610a8580d3e94cfdb' --Locked
+)
+SELECT
+    r.block_number,
+    r.block_timestamp,
+    r.origin_function_signature,
+    r.origin_from_address,
+    r.origin_to_address,
+    r.tx_hash,
+    r.event_index,
+    r.topic_0,
+    r.event_name,
+    r.event_removed,
+    r.tx_status,
+    r.contract_address AS bridge_address,
+    r.name AS platform,
+    l.from_address AS sender,
+    sender AS receiver,
+    receiver AS destination_chain_receiver,
+    l.amount,
+    r.chainIdTo AS destination_chain_id,
+    l.token AS token_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    requestsent r
+    LEFT JOIN locked l USING(
+        block_number,
+        tx_hash
+    )
+WHERE token_address IS NOT NULL

--- a/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.yml
+++ b/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.yml
@@ -1,0 +1,74 @@
+version: 2
+models:
+  - name: silver_bridge__eywa_requestsent
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: EVENT_NAME
+        tests:
+          - not_null
+      - name: BRIDGE_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: RECEIVER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: DESTINATION_CHAIN_RECEIVER
+        tests:
+          - not_null
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - DECIMAL
+                - FLOAT
+                - NUMBER
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -115,6 +115,78 @@ WHERE
     )
 {% endif %}
 ),
+dln_debridge AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        tx_hash,
+        event_index,
+        bridge_address,
+        event_name,
+        platform,
+        'v1' AS version,
+        sender,
+        receiver,
+        destination_chain_receiver,
+        destination_chain_id :: STRING AS destination_chain_id,
+        destination_chain,
+        token_address,
+        NULL AS token_symbol,
+        amount AS amount_unadj,
+        _log_id AS _id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver_bridge__dln_debridge_createdorder') }}
+
+{% if is_incremental() and 'dln_debridge' not in var('HEAL_CURATED_MODEL') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
+eywa AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        tx_hash,
+        event_index,
+        bridge_address,
+        event_name,
+        platform,
+        'v1' AS version,
+        sender,
+        receiver,
+        destination_chain_receiver,
+        destination_chain_id :: STRING AS destination_chain_id,
+        NULL AS destination_chain,
+        token_address,
+        NULL AS token_symbol,
+        amount AS amount_unadj,
+        _log_id AS _id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver_bridge__eywa_requestsent') }}
+
+{% if is_incremental() and 'eywa' not in var('HEAL_CURATED_MODEL') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
 hop AS (
     SELECT
         block_number,
@@ -418,6 +490,16 @@ all_protocols AS (
         *
     FROM
         celer_cbridge
+    UNION ALL
+    SELECT
+        *
+    FROM
+        dln_debridge
+    UNION ALL
+    SELECT
+        *
+    FROM
+        eywa
     UNION ALL
     SELECT
         *


### PR DESCRIPTION
1. Adds two new bridge protocols

`dbt run -m models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.sql --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql+ --var '{"HEAL_CURATED_MODEL":["dln_debridge","eywa"]}'`