### PR TITLE
AN-4568/across-v3-bridge

### DIFF
--- a/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.sql
+++ b/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.sql
@@ -1,0 +1,105 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = "block_number",
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH base_evt AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'across-v3' AS NAME,
+        event_index,
+        topics [0] :: STRING AS topic_0,
+        event_name,
+        TRY_TO_NUMBER(
+            decoded_flat :"depositId" :: STRING
+        ) AS depositId,
+        decoded_flat :"depositor" :: STRING AS depositor,
+        TRY_TO_NUMBER(
+            decoded_flat :"destinationChainId" :: STRING
+        ) AS destinationChainId,
+        decoded_flat :"message" :: STRING AS message,
+        TRY_TO_TIMESTAMP(
+            decoded_flat :"quoteTimestamp" :: STRING
+        ) AS quoteTimestamp,
+        decoded_flat :"recipient" :: STRING AS recipient,
+        TRY_TO_NUMBER(
+            decoded_flat :"relayerFeePct" :: STRING
+        ) AS relayerFeePct,
+        decoded_flat :"exclusiveRelayer" :: STRING AS exclusiveRelayer,
+        TRY_TO_NUMBER(
+            decoded_flat :"exclusivityDeadline" :: STRING
+        ) AS exclusivityDeadline,
+        TRY_TO_NUMBER(
+            decoded_flat :"fillDeadline" :: STRING
+        ) AS fillDeadline,
+        TRY_TO_NUMBER(
+            decoded_flat :"inputAmount" :: STRING
+        ) AS inputAmount,
+        decoded_flat :"inputToken" :: STRING AS inputToken,
+        TRY_TO_NUMBER(
+            decoded_flat :"outputAmount" :: STRING
+        ) AS outputAmount,
+        decoded_flat :"outputToken" :: STRING AS outputToken,
+        decoded_flat,
+        event_removed,
+        tx_status,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__decoded_logs') }}
+    WHERE
+        topics [0] :: STRING = '0xa123dc29aebf7d0c3322c8eeb5b999e859f39937950ed31056532713d0de396f'
+        AND contract_address = '0x6f26bf09b1c792e3228e5467807a900a503c0281'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    topic_0,
+    event_name,
+    event_removed,
+    tx_status,
+    contract_address AS bridge_address,
+    NAME AS platform,
+    depositor AS sender,
+    recipient AS receiver,
+    recipient AS destination_chain_receiver,
+    destinationChainId AS destination_chain_id,
+    inputAmount AS amount,
+    inputToken AS token_address,
+    depositId AS deposit_id,
+    message,
+    quoteTimestamp AS quote_timestamp,
+    relayerFeePct AS relayer_fee_pct,
+    exclusiveRelayer AS exclusive_relayer,
+    exclusivityDeadline AS exclusivity_deadline,
+    fillDeadline AS fill_deadline,
+    outputAmount AS output_amount,
+    outputToken AS output_token,
+    _log_id,
+    _inserted_timestamp
+FROM
+    base_evt

--- a/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.yml
+++ b/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: silver_bridge__across_fundsdeposited
+  - name: silver_bridge__across_v3fundsdeposited
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -67,3 +67,8 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: _INSERTED_TIMESTAMP
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -43,6 +43,43 @@ WHERE
     )
 {% endif %}
 ),
+across_v3 AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        tx_hash,
+        event_index,
+        bridge_address,
+        event_name,
+        platform,
+        'v3' AS version,
+        sender,
+        receiver,
+        destination_chain_receiver,
+        destination_chain_id :: STRING AS destination_chain_id,
+        NULL AS destination_chain,
+        token_address,
+        NULL AS token_symbol,
+        amount AS amount_unadj,
+        _log_id AS _id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver_bridge__across_v3fundsdeposited') }}
+
+{% if is_incremental() and 'across_v3' not in var('HEAL_CURATED_MODEL') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        FROM
+            {{ this }}
+    )
+{% endif %}
+),
 axelar AS (
     SELECT
         block_number,
@@ -480,6 +517,11 @@ all_protocols AS (
         *
     FROM
         across
+    UNION ALL
+    SELECT
+        *
+    FROM
+        across_v3
     UNION ALL
     SELECT
         *


### PR DESCRIPTION
1. Added Across V3 Bridge models
2. Updated complete bridging
3. Removed recency on prior version

`dbt run -m models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.sql --full-refresh && dbt run -m models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql --vars '{"HEAL_CURATED_MODEL":["across_v3"]}'`