### PR TITLE
An 5823 - Update fsc utils package + fix ABI request

### DIFF
--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -59,7 +59,7 @@ SELECT
             'fsc-quantum-state', 'livequery'
         ),
         NULL,
-        'Vault/prod/block_explorers/op_etherscan'
+        'Vault/prod/block_explorers/optimism_scan'
         ) AS abi_data,
     SYSDATE() AS _inserted_timestamp
 FROM

--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -50,7 +50,18 @@ row_nos AS (
 ),
 batched AS ({% for item in range(501) %}
 SELECT
-    rn.contract_address, live.udf_api('GET', CONCAT('https://api-optimistic.etherscan.io/api?module=contract&action=getabi&address=', rn.contract_address, '&apikey={key}'),{ 'User-Agent': 'FlipsideStreamline' },{}, 'Vault/prod/block_explorers/op_etherscan') AS abi_data, SYSDATE() AS _inserted_timestamp
+    rn.contract_address, 
+    live.udf_api(
+        'GET', 
+        CONCAT('https://api-optimistic.etherscan.io/api?module=contract&action=getabi&address=', rn.contract_address, '&apikey={key}'),
+        OBJECT_CONSTRUCT(
+            'Content-Type', 'application/json',
+            'fsc-quantum-state', 'livequery'
+        ),
+        NULL,
+        'Vault/prod/block_explorers/op_etherscan'
+        ) AS abi_data,
+    SYSDATE() AS _inserted_timestamp
 FROM
     row_nos rn
 WHERE

--- a/packages.yml
+++ b/packages.yml
@@ -6,7 +6,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.31.0
+    revision: v1.33.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]
   - git: https://github.com/FlipsideCrypto/fsc-evm.git


### PR DESCRIPTION

-- delete from optimism.bronze_api.contract_abis
-- where _inserted_timestamp >= '2025-02-19 00:11:16.679';


-- DROP SCHEMA optimism._live;
-- DROP SCHEMA optimism._utils;
-- DROP SCHEMA optimism.live;
-- DROP SCHEMA optimism.utils;

dbt run -m livequery_base.deploy.core --vars '{UPDATE_UDFS_AND_SPS: true}' --target prod

;


-- SHOW GRANTS ON FUNCTION optimism._LIVE.UDF_API(VARCHAR, VARCHAR, OBJECT, VARIANT, VARCHAR, VARCHAR);
--  GRANT USAGE ON SCHEMA optimism._live TO AWS_LAMBDA_optimism_API;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA optimism._live TO AWS_LAMBDA_optimism_API;
--  GRANT USAGE ON SCHEMA optimism._live TO DBT_CLOUD_optimism;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA optimism._live TO DBT_CLOUD_optimism;
-- SHOW GRANTS ON FUNCTION optimism._UTILS.UDF_INTROSPECT(VARCHAR);
--  GRANT USAGE ON SCHEMA optimism._utils TO AWS_LAMBDA_optimism_API;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA optimism._utils TO AWS_LAMBDA_optimism_API;
--  GRANT USAGE ON SCHEMA optimism._utils TO DBT_CLOUD_optimism;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA optimism._utils TO DBT_CLOUD_optimism;

